### PR TITLE
Fix About the Author Twitter URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ If you like this project, consider following my work across platforms:
 - 💻 **Blog**: [ElBruno.com](https://elbruno.com) — Deep dives on embeddings, RAG, .NET, and local AI
 - 📺 **YouTube**: [youtube.com/elbruno](https://www.youtube.com/elbruno) — Demos, tutorials, and live coding
 - 🔗 **LinkedIn**: [@elbruno](https://www.linkedin.com/in/elbruno/) — Professional updates and insights
-- 𝕏 **Twitter**: [@elbruno](https://www.x.com/in/elbruno/) — Quick tips, releases, and tech news
+- 𝕏 **Twitter**: [@elbruno](https://www.x.com/elbruno/) — Quick tips, releases, and tech news
 
 ## License
 


### PR DESCRIPTION
Updates the README About the Author section to use the correct Twitter/X URL: https://www.x.com/elbruno/.

Fixes #46