### PR TITLE
Fix misleading OTEL server tags for LocalEmbeddingGenerator metadata

### DIFF
--- a/src/ElBruno.LocalEmbeddings/LocalEmbeddingGenerator.cs
+++ b/src/ElBruno.LocalEmbeddings/LocalEmbeddingGenerator.cs
@@ -88,7 +88,7 @@ public sealed class LocalEmbeddingGenerator : IEmbeddingGenerator<string, Embedd
         // Create metadata
         _metadata = new EmbeddingGeneratorMetadata(
             providerName: "LocalEmbeddings",
-            providerUri: new Uri("https://github.com/elbruno/elbruno.localembeddings"),
+            providerUri: null,
             defaultModelId: options.ModelName,
             defaultModelDimensions: _model.EmbeddingDimension);
     }

--- a/src/Tests/ElBruno.LocalEmbeddings.Tests/LocalEmbeddingGeneratorTests.cs
+++ b/src/Tests/ElBruno.LocalEmbeddings.Tests/LocalEmbeddingGeneratorTests.cs
@@ -254,7 +254,7 @@ public class LocalEmbeddingGeneratorTests
 
         Assert.NotNull(generator.Metadata);
         Assert.Equal("LocalEmbeddings", generator.Metadata.ProviderName);
-        Assert.NotNull(generator.Metadata.ProviderUri);
+        Assert.Null(generator.Metadata.ProviderUri);
         Assert.Equal("sentence-transformers/all-MiniLM-L6-v2", generator.Metadata.DefaultModelId);
         Assert.Equal(384, generator.Metadata.DefaultModelDimensions);
     }


### PR DESCRIPTION
## Summary\n- set LocalEmbeddingGenerator metadata providerUri to 
ull\n- keep provider/model/dimension metadata unchanged\n- update metadata test to assert ProviderUri is null\n\n## Why\nFor local, in-process embeddings there is no network endpoint. A non-null URI causes MEAI OTEL instrumentation to emit misleading server.address/server.port tags.\n\nCloses #50