### PR TITLE
fix: net8.0+net10.0 multi-targeting confirmed, docs and publish pipeline updated (closes #52)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,8 @@ jobs:
           dotnet pack src/ElBruno.LocalEmbeddings.ImageEmbeddings.Downloader/ElBruno.LocalEmbeddings.ImageEmbeddings.Downloader.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts
           dotnet pack src/ElBruno.LocalEmbeddings.KernelMemory/ElBruno.LocalEmbeddings.KernelMemory.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts
           dotnet pack src/ElBruno.LocalEmbeddings.VectorData/ElBruno.LocalEmbeddings.VectorData.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts
+          dotnet pack src/ElBruno.LocalEmbeddings.Azure/ElBruno.LocalEmbeddings.Azure.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts
+          dotnet pack src/ElBruno.LocalEmbeddings.OpenTelemetry/ElBruno.LocalEmbeddings.OpenTelemetry.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts
           dotnet pack src/ElBruno.LocalEmbeddings.Npu/ElBruno.LocalEmbeddings.Npu.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts
           dotnet pack src/ElBruno.LocalEmbeddings.Npu.Intel/ElBruno.LocalEmbeddings.Npu.Intel.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts
           dotnet pack src/ElBruno.LocalEmbeddings.Npu.Qualcomm/ElBruno.LocalEmbeddings.Npu.Qualcomm.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Interested in **image embeddings**? Check out the **[YouTube video](https://www.
 ## Features
 
 - **Local Embedding Generation** — Run inference entirely on your machine using ONNX Runtime
+- **Multi-Framework** — Targets **.NET 8.0 (LTS)** and **.NET 10.0**
 - **Microsoft.Extensions.AI Integration** — Implements `IEmbeddingGenerator<string, Embedding<float>>`
 - **🦅 Harrier model support** — Microsoft Harrier-OSS-v1 (270M, 640-dim, 94+ languages, instruction-tuned) via `ElBruno.LocalEmbeddings.Harrier`
 - **Kernel Memory Integration** — Companion package `ElBruno.LocalEmbeddings.KernelMemory` provides a native `ITextEmbeddingGenerator` adapter for [Microsoft Kernel Memory](https://github.com/microsoft/kernel-memory)
@@ -211,7 +212,7 @@ dotnet test
 
 ## Requirements
 
-- .NET 10.0 SDK or later
+- .NET 8.0 SDK (LTS) or .NET 10.0 SDK
 - ONNX Runtime compatible platform (Windows, Linux, macOS)
 
 ## 👋 About the Author

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET 10.0 SDK](https://dotnet.microsoft.com/download) or later
+- [.NET 8.0 SDK (LTS)](https://dotnet.microsoft.com/download) or [.NET 10.0 SDK](https://dotnet.microsoft.com/download)
 - Git
 
 ## Getting Started
@@ -76,7 +76,7 @@ dotnet test
 - All extended documentation goes in `docs/`.
 - The NuGet package IDs are always prefixed with `ElBruno.` (e.g., `ElBruno.LocalEmbeddings`, `ElBruno.LocalEmbeddings.KernelMemory`).
 - The core `ElBruno.LocalEmbeddings` package must **not** depend on Kernel Memory — KM integration lives in the companion package.
-- Target .NET 10.0 or later.
+- Target .NET 8.0 or later (both `net8.0` and `net10.0` are supported).
 
 ## Get Involved & Stay Connected
 

--- a/src/ElBruno.LocalEmbeddings.Azure/ElBruno.LocalEmbeddings.Azure.csproj
+++ b/src/ElBruno.LocalEmbeddings.Azure/ElBruno.LocalEmbeddings.Azure.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;azure;openai;fallback;ai;local;microsoft-extensions-ai</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElBruno.LocalEmbeddings.Harrier/ElBruno.LocalEmbeddings.Harrier.csproj
+++ b/src/ElBruno.LocalEmbeddings.Harrier/ElBruno.LocalEmbeddings.Harrier.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;onnx;ai;local;harrier;microsoft-extensions-ai;multilingual;decoder-only</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElBruno.LocalEmbeddings.ImageEmbeddings.Downloader/ElBruno.LocalEmbeddings.ImageEmbeddings.Downloader.csproj
+++ b/src/ElBruno.LocalEmbeddings.ImageEmbeddings.Downloader/ElBruno.LocalEmbeddings.ImageEmbeddings.Downloader.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;onnx;ai;local;clip;image-embeddings;model-downloader;huggingface</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElBruno.LocalEmbeddings.ImageEmbeddings/ElBruno.LocalEmbeddings.ImageEmbeddings.csproj
+++ b/src/ElBruno.LocalEmbeddings.ImageEmbeddings/ElBruno.LocalEmbeddings.ImageEmbeddings.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;onnx;ai;local;clip;image-search;multimodal;microsoft-extensions-ai</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElBruno.LocalEmbeddings.KernelMemory/ElBruno.LocalEmbeddings.KernelMemory.csproj
+++ b/src/ElBruno.LocalEmbeddings.KernelMemory/ElBruno.LocalEmbeddings.KernelMemory.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;onnx;ai;local;kernel-memory;semantic-memory;microsoft-extensions-ai;sentence-transformers</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.5.2</Version>
     <NoWarn>$(NoWarn);KMEXP00</NoWarn>
   </PropertyGroup>
 

--- a/src/ElBruno.LocalEmbeddings.Npu.Intel/ElBruno.LocalEmbeddings.Npu.Intel.csproj
+++ b/src/ElBruno.LocalEmbeddings.Npu.Intel/ElBruno.LocalEmbeddings.Npu.Intel.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;onnx;ai;local;npu;intel;core-ultra;openvino;hardware-acceleration;microsoft-extensions-ai;sentence-transformers;nlp;machine-learning</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <!-- Standalone library — does NOT reference the base ElBruno.LocalEmbeddings project

--- a/src/ElBruno.LocalEmbeddings.Npu.Qualcomm/ElBruno.LocalEmbeddings.Npu.Qualcomm.csproj
+++ b/src/ElBruno.LocalEmbeddings.Npu.Qualcomm/ElBruno.LocalEmbeddings.Npu.Qualcomm.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;onnx;ai;local;npu;qualcomm;snapdragon;qnn;hardware-acceleration;microsoft-extensions-ai;sentence-transformers;nlp;machine-learning</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElBruno.LocalEmbeddings.Npu/ElBruno.LocalEmbeddings.Npu.csproj
+++ b/src/ElBruno.LocalEmbeddings.Npu/ElBruno.LocalEmbeddings.Npu.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;onnx;ai;local;npu;directml;gpu;hardware-acceleration;microsoft-extensions-ai;sentence-transformers;nlp;machine-learning</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElBruno.LocalEmbeddings.OpenTelemetry/ElBruno.LocalEmbeddings.OpenTelemetry.csproj
+++ b/src/ElBruno.LocalEmbeddings.OpenTelemetry/ElBruno.LocalEmbeddings.OpenTelemetry.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;opentelemetry;observability;tracing;metrics;jaeger;datadog;azure-monitor;distributed-tracing</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.5.2</Version>
     <NoWarn>$(NoWarn);NU1902</NoWarn>
   </PropertyGroup>
 

--- a/src/ElBruno.LocalEmbeddings.VectorData/ElBruno.LocalEmbeddings.VectorData.csproj
+++ b/src/ElBruno.LocalEmbeddings.VectorData/ElBruno.LocalEmbeddings.VectorData.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;onnx;ai;local;microsoft-extensions-ai;vectordata;semantic-search</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElBruno.LocalEmbeddings/ElBruno.LocalEmbeddings.csproj
+++ b/src/ElBruno.LocalEmbeddings/ElBruno.LocalEmbeddings.csproj
@@ -16,7 +16,7 @@
     <PackageIcon>icon_03.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>embeddings;onnx;ai;local;microsoft-extensions-ai;sentence-transformers;nlp;machine-learning</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/ElBruno.LocalEmbeddings.Tests/TargetFrameworkCompatibilityTests.cs
+++ b/src/Tests/ElBruno.LocalEmbeddings.Tests/TargetFrameworkCompatibilityTests.cs
@@ -1,0 +1,137 @@
+using System.Runtime.InteropServices;
+using ElBruno.LocalEmbeddings.Extensions;
+using ElBruno.LocalEmbeddings.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace ElBruno.LocalEmbeddings.Tests;
+
+/// <summary>
+/// Verifies that the public API surface works correctly on both net8.0 and net10.0.
+/// All tests are model-free (no ONNX file required) so they run reliably on CI.
+/// </summary>
+public class TargetFrameworkCompatibilityTests
+{
+    // =========================================================================
+    // Runtime verification
+    // =========================================================================
+
+    [Fact]
+    public void RuntimeFramework_IsSupported()
+    {
+        string framework = RuntimeInformation.FrameworkDescription;
+        Assert.False(string.IsNullOrEmpty(framework));
+
+        // Must be .NET 8+ (net8.0 or net10.0)
+        bool isNet8Plus =
+            framework.Contains(".NET 8", StringComparison.OrdinalIgnoreCase) ||
+            framework.Contains(".NET 9", StringComparison.OrdinalIgnoreCase) ||
+            framework.Contains(".NET 10", StringComparison.OrdinalIgnoreCase);
+        Assert.True(isNet8Plus, $"Unexpected runtime: {framework}");
+    }
+
+    // =========================================================================
+    // Cosine similarity — TensorPrimitives path (available net8.0+)
+    // =========================================================================
+
+    public static TheoryData<float[], float[], float> CosineSimilarityData => new()
+    {
+        { new float[] { 1f, 0f, 0f }, new float[] { 1f, 0f, 0f }, 1.0f },
+        { new float[] { 1f, 0f, 0f }, new float[] { 0f, 1f, 0f }, 0.0f },
+        { new float[] { 1f, 0f, 0f }, new float[] { -1f, 0f, 0f }, -1.0f },
+        { new float[] { 3f, 4f, 0f }, new float[] { 3f, 4f, 0f }, 1.0f },
+    };
+
+    [Theory]
+    [MemberData(nameof(CosineSimilarityData))]
+    public void CosineSimilarity_ReturnsCorrectValue(float[] a, float[] b, float expected)
+    {
+        var memA = new ReadOnlyMemory<float>(a);
+        var memB = new ReadOnlyMemory<float>(b);
+
+        float actual = memA.CosineSimilarity(memB);
+
+        Assert.InRange(actual, expected - 1e-5f, expected + 1e-5f);
+    }
+
+    // =========================================================================
+    // EmbeddingExtensions — FindClosest on pre-computed embeddings
+    // =========================================================================
+
+    [Fact]
+    public void FindClosest_ReturnsCorrectMatch()
+    {
+        var query = new Embedding<float>(new float[] { 1f, 0f, 0f });
+        var candidates = new[]
+        {
+            new Embedding<float>(new float[] { 0f, 1f, 0f }),  // orthogonal
+            new Embedding<float>(new float[] { 1f, 0f, 0f }),  // identical — should win
+            new Embedding<float>(new float[] { -1f, 0f, 0f }), // opposite
+        };
+
+        // FindClosest is an extension on IEnumerable<(T, Embedding<float>)>; test the underlying
+        // CosineSimilarity primitive instead, which FindClosest is built on.
+        Embedding<float> closest = candidates
+            .OrderByDescending(c => query.CosineSimilarity(c))
+            .First();
+
+        Assert.Equal(candidates[1].Vector.ToArray(), closest.Vector.ToArray());
+    }
+
+    // =========================================================================
+    // LocalEmbeddingsOptions — defaults
+    // =========================================================================
+
+    [Fact]
+    public void LocalEmbeddingsOptions_DefaultsAreSet()
+    {
+        var options = new LocalEmbeddingsOptions();
+
+        Assert.False(string.IsNullOrWhiteSpace(options.ModelName));
+        Assert.True(options.MaxSequenceLength > 0);
+    }
+
+    // =========================================================================
+    // DI registration — AddLocalEmbeddings does not throw
+    // =========================================================================
+
+    [Fact]
+    public void AddLocalEmbeddings_RegistersExpectedServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddLocalEmbeddings(opts =>
+        {
+            opts.ModelName = "sentence-transformers/all-MiniLM-L6-v2";
+            opts.EnsureModelDownloaded = false;
+        });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        // Options can be resolved
+        var options = provider.GetRequiredService<IOptions<LocalEmbeddingsOptions>>().Value;
+        Assert.Equal("sentence-transformers/all-MiniLM-L6-v2", options.ModelName);
+
+        // IEmbeddingGenerator is registered (factory, not resolved — avoids file I/O)
+        bool generatorRegistered = services.Any(
+            s => s.ServiceType == typeof(IEmbeddingGenerator<string, Embedding<float>>));
+        Assert.True(generatorRegistered);
+    }
+
+    // =========================================================================
+    // Embedding<float> — basic value round-trip
+    // =========================================================================
+
+    [Fact]
+    public void EmbeddingFloat_VectorRoundTrip()
+    {
+        float[] values = new float[] { 0.1f, 0.2f, 0.3f, 0.4f };
+        var embedding = new Embedding<float>(values);
+
+        float[] roundTripped = embedding.Vector.ToArray();
+
+        Assert.Equal(values, roundTripped);
+    }
+}
+


### PR DESCRIPTION
## Summary

Resolves #52 — ElBruno.LocalEmbeddings 1.0.1 only targeting 
et10.0.

### Root Cause
The old published NuGet package (v1.0.1) pre-dated multi-targeting support. The source code already contained <TargetFrameworks>net8.0;net10.0</TargetFrameworks> for all libraries, and NuGet v1.5.1 already shipped both TFMs. This release (v1.5.2) formalises that support with tests, documentation, and a corrected publish pipeline.

### Changes

| Area | What changed |
|------|-------------|
| **New test** | \TargetFrameworkCompatibilityTests.cs\ — 9 model-free tests covering cosine similarity, DI registration, options defaults, and vector round-trip; all 9 pass on both net8.0 and net10.0 |
| **README.md** | Requirements updated: \.NET 10.0 SDK or later\ → \.NET 8.0 SDK (LTS) or .NET 10.0 SDK\; new Multi-Framework feature bullet |
| **docs/contributing.md** | Prerequisites updated to match |
| **publish.yml** | Added \ElBruno.LocalEmbeddings.Azure\ and \ElBruno.LocalEmbeddings.OpenTelemetry\ to the pack/push steps (both existed in source but were missing from the pipeline) |
| **11 library .csproj files** | \<Version>\ default bumped from \1.0.x\/\1.0.0\ → \1.5.2\ |

### Test Results
\\\
Passed!  - Failed: 0, Passed: 347, Skipped: 36, Total: 383 — net8.0
Passed!  - Failed: 0, Passed: 347, Skipped: 36, Total: 383 — net10.0
\\\

### Next Step
After merge, create GitHub release \1.5.2\ to trigger \publish.yml\ and push all 11 packages (including the two new ones) to NuGet.