### PR TITLE
Enforce Blazor component implementation requirements in issue automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/blazor-components-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/blazor-components-implementation.yml
@@ -1,0 +1,53 @@
+name: Blazor components implementation
+description: Request a Blazor components implementation change with full delivery requirements
+title: "feat: [Blazor] "
+labels:
+  - squad
+  - type:feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Issues created with this template are considered complete only when implementation, validation, documentation, and release tasks are all done.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Feature summary
+      description: Describe the requested Blazor component capability and expected user value.
+      placeholder: Add a new component or update an existing one...
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Implementation scope
+      description: List target components, API contracts, and sample app touchpoints.
+      placeholder: Components, public parameters/events, sample updates...
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: required-deliverables
+    attributes:
+      label: Required implementation deliverables
+      description: All items are mandatory for completion.
+      options:
+        - label: New or updated Blazor component code will be implemented
+          required: true
+        - label: New or updated automated tests will be added
+          required: true
+        - label: New or updated sample application changes will be included
+          required: true
+        - label: New or updated main documentation will be included
+          required: true
+        - label: New or updated sample-application documentation will be included
+          required: true
+        - label: All relevant tests must be green before closing
+          required: true
+        - label: A NuGet release is required for completion
+          required: true
+        - label: README "What's New" will be evaluated and updated when needed for the release
+          required: true
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -325,6 +325,7 @@ public const long MaxModelSizeBytes = 1024 * 1024 * 1024; // 1GB
 
 - If a new packable library project is added under `src/`, update `.github/workflows/publish.yml` in the same change so the package is packed and published.
 - Also update `docs/publishing.md` and NuGet Trusted Publishing guidance for the added package.
+- Keep a `What's New` section in `README.md` with the **last 5 notable features** only; on every NuGet release, validate whether a new entry must be added.
 
 - @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
 - @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,28 @@ jobs:
       - name: Test
         run: dotnet test -c Release --no-build --verbosity normal
 
+      - name: Validate README What's New policy
+        run: |
+          SECTION=$(awk '/^## .*What'"'"'s New/{flag=1;next}/^## /{flag=0}flag{print}' README.md)
+          if [[ -z "$SECTION" ]]; then
+            echo "❌ README.md must contain a What's New section."
+            exit 1
+          fi
+
+          BULLET_COUNT=$(printf "%s\n" "$SECTION" | grep -E '^- ' | wc -l | xargs)
+          TABLE_COUNT=$(printf "%s\n" "$SECTION" | grep -E '^\| \*\*v' | wc -l | xargs)
+          ITEM_COUNT="$BULLET_COUNT"
+          if [[ "$TABLE_COUNT" -gt "$ITEM_COUNT" ]]; then
+            ITEM_COUNT="$TABLE_COUNT"
+          fi
+
+          if [[ "$ITEM_COUNT" -ne 5 ]]; then
+            echo "❌ What's New must keep exactly the last 5 notable entries. Found: $ITEM_COUNT"
+            exit 1
+          fi
+
+          echo "✅ README What's New policy passed (5 entries)."
+
       - name: Pack
         run: |
           dotnet pack src/ElBruno.LocalEmbeddings/ElBruno.LocalEmbeddings.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -23,6 +23,28 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
             const label = context.payload.label.name;
+            const issueText = `${issue.title}\n${issue.body || ''}`.toLowerCase();
+            const isBlazorComponentsIssue =
+              issueText.includes('blazorcomponents') ||
+              issueText.includes('blazor components') ||
+              issueText.includes('razor component') ||
+              (issueText.includes('blazor') && issueText.includes('component'));
+            const hasImplementationLabel = issue.labels.some(l => l.name === 'implementation:blazor-components');
+            const needsBlazorChecklist = hasImplementationLabel || isBlazorComponentsIssue;
+
+            const blazorChecklist = [
+              `### ✅ Blazor Components Implementation Requirements`,
+              ``,
+              `This issue is considered complete only when all of the following are delivered:`,
+              `- [ ] New or updated Blazor component code`,
+              `- [ ] New or updated automated tests`,
+              `- [ ] New or updated sample application changes`,
+              `- [ ] New or updated main documentation`,
+              `- [ ] New or updated sample-application documentation`,
+              `- [ ] Test suite is green`,
+              `- [ ] NuGet release is published`,
+              `- [ ] README "What's New" entry was evaluated and updated when needed`
+            ].join('\n');
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -85,6 +107,8 @@ jobs:
                 '',
                 `> The coding agent will create a \`copilot/*\` branch and open a draft PR.`,
                 `> Review the PR as you would any team member's work.`,
+                needsBlazorChecklist ? `` : '',
+                needsBlazorChecklist ? blazorChecklist : '',
               ].join('\n');
             } else {
               comment = [
@@ -97,6 +121,8 @@ jobs:
                 `> **For Copilot coding agent:** If enabled, this issue will be worked automatically.`,
                 `> Otherwise, start a Copilot session and say:`,
                 `> \`${assignedMember.name}, work on issue #${issue.number}\``,
+                needsBlazorChecklist ? `` : '',
+                needsBlazorChecklist ? blazorChecklist : '',
               ].join('\n');
             }
 

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -79,6 +79,28 @@ jobs:
 
                   core.info('Applied release:backlog for go:yes issue');
                 }
+
+                const hasBlazorImplementationLabel = allLabels.includes('implementation:blazor-components');
+                if (hasBlazorImplementationLabel) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: [
+                      `🧩 This issue is marked with \`implementation:blazor-components\`.`,
+                      ``,
+                      `Before closing, ensure these deliverables are complete:`,
+                      `- New or updated Blazor component code`,
+                      `- New or updated tests`,
+                      `- New or updated sample app changes`,
+                      `- New or updated documentation`,
+                      `- New or updated sample-app documentation`,
+                      `- Green test run`,
+                      `- NuGet release published`,
+                      `- README "What's New" reviewed and updated when needed`
+                    ].join('\n')
+                  });
+                }
               }
 
               // Remove release: labels if go:no

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -129,7 +129,7 @@ jobs:
               `- [ ] Test suite is green`,
               `- [ ] NuGet release is published`,
               `- [ ] README "What's New" entry was evaluated and updated when needed`
-            ].join('\\n');
+            ].join('\n');
 
             let assignedMember = null;
             let triageReason = '';

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -111,6 +111,25 @@ jobs:
 
             // Determine best assignee based on issue content and routing
             const issueText = `${issue.title}\n${issue.body || ''}`.toLowerCase();
+            const isBlazorComponentsIssue =
+              issueText.includes('blazorcomponents') ||
+              issueText.includes('blazor components') ||
+              issueText.includes('razor component') ||
+              (issueText.includes('blazor') && issueText.includes('component'));
+
+            const blazorChecklist = [
+              `### ✅ Blazor Components Implementation Requirements`,
+              ``,
+              `This issue is considered complete only when all of the following are delivered:`,
+              `- [ ] New or updated Blazor component code`,
+              `- [ ] New or updated automated tests`,
+              `- [ ] New or updated sample application changes`,
+              `- [ ] New or updated main documentation`,
+              `- [ ] New or updated sample-application documentation`,
+              `- [ ] Test suite is green`,
+              `- [ ] NuGet release is published`,
+              `- [ ] README "What's New" entry was evaluated and updated when needed`
+            ].join('\\n');
 
             let assignedMember = null;
             let triageReason = '';
@@ -201,6 +220,15 @@ jobs:
               labels: ['go:needs-research']
             });
 
+            if (isBlazorComponentsIssue) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['implementation:blazor-components']
+              });
+            }
+
             // Auto-assign @copilot if enabled
             if (isCopilot && copilotAutoAssign) {
               try {
@@ -234,6 +262,7 @@ jobs:
               `**Reason:** ${triageReason}`,
               copilotTier === 'needs-review' ? `\n⚠️ **PR review recommended** — a squad member should review @copilot's work on this one.` : '',
               copilotNote,
+              isBlazorComponentsIssue ? `\n${blazorChecklist}` : '',
               '',
               `---`,
               '',

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -98,6 +98,10 @@ jobs:
               { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
             ];
 
+            const IMPLEMENTATION_LABELS = [
+              { name: 'implementation:blazor-components', color: '6A5ACD', description: 'Requires full Blazor components implementation checklist (code, tests, samples, docs, release)' }
+            ];
+
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
 
             // Ensure the base "squad" triage label exists
@@ -127,6 +131,7 @@ jobs:
             labels.push(...RELEASE_LABELS);
             labels.push(...TYPE_LABELS);
             labels.push(...PRIORITY_LABELS);
+            labels.push(...IMPLEMENTATION_LABELS);
             labels.push(...SIGNAL_LABELS);
 
             // Sync labels (create or update)


### PR DESCRIPTION
## Summary\n- add a dedicated Blazor components issue template with mandatory delivery checklist\n- update squad triage/assignment/label workflows to auto-tag Blazor-component issues and post implementation requirements\n- add release-time README What's New validation to publish workflow\n- add repository instruction requiring the last 5 notable What's New entries\n\n## Why\nThe previous issue flow allowed issue creation without explicitly enforcing full implementation deliverables for Blazor components.